### PR TITLE
Upgrade qudt to 3.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ This Changelog contains the changes for all packages of this monorepo, which all
 
 ### Changed
 
-- Simplified BEST_MATCH algorithm for obtaining a unit from a set of factor units. Recent additions to the data model (isScalingOf and factorUnit relationships) led to a larger set of candidates and the complexity of the previous algorithm led to very high computation time.
+- Simplified BEST_MATCH algorithm for obtaining a unit from a set of factor units. Recent additions to the data model (scalingOf and factorUnit relationships) led to a larger set of candidates and the complexity of the previous algorithm led to very high computation time.
 - Changed the behaviour of Unit.hasFactorUnits() such that for a FactorUnits object with only one top-level factor unit (such as [N^1]), the method returns false.
 
 ## 6.0.0 - 2023-12-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This Changelog contains the changes for all packages of this monorepo, which all
 
 ## Unreleased
 
+### Changed
+
+- Upgrade to QUDT 3.1.5
+  QUDT now contains many more language-specific `rdfs:label`s. QUDTLib selects only `en` and `en-US` labels
+  (`en` is standard and together with `en-US` the labels meet the expectations of most romanic language users)
+
+### Fixed
+
+- Fixed handling of Currency units.
+- Special handling of KiloGM in Qudt.scale()
+- Exported more functions
+
 ## 7.0.0-beta.1 - 2025-07-26
 
 ### Added

--- a/core/src/assignmentProblem.ts
+++ b/core/src/assignmentProblem.ts
@@ -89,7 +89,7 @@ export class Solution {
   }
 }
 
-class ValueWithIndex {
+export class ValueWithIndex {
   readonly value: number;
   readonly index: number;
 

--- a/core/src/qudt.ts
+++ b/core/src/qudt.ts
@@ -622,15 +622,15 @@ export class Qudt {
       prefix instanceof Prefix ? prefix : this.prefixRequired(prefix);
     const theUnit =
       baseUnit instanceof Unit ? baseUnit : this.unitRequired(baseUnit);
+    // special case: KiloGM is not a scaling of GM, it's the other way round. Handle special case here.
+    if (thePrefix.iri.endsWith("/Kilo") && theUnit.iri.endsWith("/GM")) {
+      return this.unitFromLocalname("KiloGM");
+    }
     const candidates = this.getUnitsWithSameDimensionVector(theUnit);
     for (const u of candidates) {
       if (u.prefix?.equals(thePrefix) && u.scalingOf?.equals(theUnit)) {
         return u;
       }
-    }
-    // special case: KiloGM is not a scaling of GM, it's the other way round. Handle special case here.
-    if (thePrefix.iri.endsWith("/Kilo") && theUnit.iri.endsWith("/GM")) {
-      return this.unitFromLocalname("KiloGM");
     }
     throw `No scaled unit found with base unit ${theUnit.toString()} and prefix ${thePrefix.toString()}`;
   }

--- a/core/src/qudtNamespaces.ts
+++ b/core/src/qudtNamespaces.ts
@@ -4,7 +4,6 @@ export const QudtNamespaces = Object.freeze({
   qudt: new Namespace("http://qudt.org/schema/qudt/", "qudt"),
   quantityKind: new Namespace("http://qudt.org/vocab/quantitykind/", "qk"),
   unit: new Namespace("http://qudt.org/vocab/unit/", "unit"),
-  currency: new Namespace("http://qudt.org/vocab/currency/", "cur"),
   prefix: new Namespace("http://qudt.org/vocab/prefix/", "prefix"),
   systemOfUnits: new Namespace("http://qudt.org/vocab/sou/", "sou"),
   dimensionVector: new Namespace(

--- a/core/src/unit.ts
+++ b/core/src/unit.ts
@@ -112,13 +112,11 @@ export class Unit implements SupportsEquals<Unit> {
   }
 
   getIriAbbreviated(): string {
-    return this.isCurrencyUnit()
-      ? QudtNamespaces.currency.abbreviate(this.iri)
-      : QudtNamespaces.unit.abbreviate(this.iri);
+    return QudtNamespaces.unit.abbreviate(this.iri);
   }
 
   isCurrencyUnit(): boolean {
-    return QudtNamespaces.currency.isFullNamespaceIri(this.iri);
+    return this.getIriLocalname().startsWith("CCY_");
   }
 
   matchesFactorUnitSpec(...factorUnitSpec: (number | Unit)[]): boolean {

--- a/core/src/utils.ts
+++ b/core/src/utils.ts
@@ -5,7 +5,7 @@ export function getLastIriElement(iri: string) {
   return iri.replaceAll(/.+\/([^\/]+)/g, "$1");
 }
 
-interface EqualsComparator<Type> {
+export interface EqualsComparator<Type> {
   (left: Type, right: Type): boolean;
 }
 


### PR DESCRIPTION
### Changed

- Upgrade to QUDT 3.1.5
  QUDT now contains many more language-specific `rdfs:label`s. QUDTLib selects only `en` and `en-US` labels
  (`en` is standard and together with `en-US` the labels meet the expectations of most romanic language users)

### Fixed

- Fixed handling of Currency units.
- Special handling of KiloGM in Qudt.scale()
- Exported more functions